### PR TITLE
Failure on non-ascii chars in error messages

### DIFF
--- a/pygit2/errors.py
+++ b/pygit2/errors.py
@@ -40,7 +40,7 @@ def check_error(err, io=False):
     # Error message
     giterr = C.giterr_last()
     if giterr != ffi.NULL:
-        message = ffi.string(giterr.message).decode()
+        message = ffi.string(giterr.message).decode('utf8')
     else:
         message = "err %d (no message provided)" % err
 


### PR DESCRIPTION
Libgit2 partially forwards OS error message texts.
I.e. the following error message (see C.giterr_last()) is generated on my german windows 10, when a fetch() is done but the remote repo is unavailable: `failed to send request: Das Zeitlimit f\xc3\xbcr den Vorgang wurde erreicht.\r\n`.

To avoid that a UnicodeDecodeError due to the contained 'ü' (encoded as '\xc3\xbc') is raised the error message must be interpreted as UTF-8.
The solution is not be necessary on linux/osx as they return always ascii (as far as I know).
Thus this solution will not change the behaviour on linux/osx but fix windows issues.
